### PR TITLE
Thato/lev 1649 fixes 03 march

### DIFF
--- a/app/components/SearchBox/FlightSearch.tsx
+++ b/app/components/SearchBox/FlightSearch.tsx
@@ -495,7 +495,7 @@ const FlightSearch = () => {
             <AntDatePicker
               onChange={runChecks}
               disabledDate={(current) =>
-                current && current < dayjs().startOf("day")
+                current && current < dayjs().startOf("day") || current > dayjs().add(12, "months").endOf("day")
               }
             />
           </Form.Item>
@@ -656,7 +656,7 @@ const FlightSearch = () => {
                             return (
                               (previousLegDate && current < dayjs(previousLegDate)) ||
                               (nextLegDate && current > dayjs(nextLegDate)) ||
-                              current < dayjs().startOf("day")
+                              current < dayjs().startOf("day") || current > dayjs().add(12, "months")
                             );
                           }}
                           onChange={(date) => {

--- a/app/components/SearchBox/FlightSearch.tsx
+++ b/app/components/SearchBox/FlightSearch.tsx
@@ -491,7 +491,12 @@ const FlightSearch = () => {
           style={{ width: "16%" }}
         >
           <InputLabel>Date</InputLabel>
-          <Form.Item name="date" initialValue={dayjs()} noStyle>
+          <Form.Item name="date" initialValue={dayjs()} noStyle rules={[
+            {
+              required: true,
+              message: "Please input your departure date",
+            },
+          ]}>
             <AntDatePicker
               onChange={runChecks}
               disabledDate={(current) =>
@@ -635,7 +640,12 @@ const FlightSearch = () => {
                       style={{ width: "16%" }}
                     >
                       <InputLabel>Date</InputLabel>
-                      <Form.Item {...restField} name={[name, "date"]} noStyle>
+                      <Form.Item {...restField} name={[name, "date"]} noStyle rules={[
+                        {
+                          required: true,
+                          message: "Please input your departure date",
+                        },
+                      ]}>
                         <AntDatePicker
                           disabledDate={(current) => {
                             const legs = form.getFieldValue("legs") || [];

--- a/app/components/SearchBox/FlightSearch.tsx
+++ b/app/components/SearchBox/FlightSearch.tsx
@@ -52,6 +52,7 @@ const FlightSearch = () => {
   const [form] = Form.useForm();
   const [airports, setAirports] = useState<IAirport[]>([]);
   const [airportResults, setAirportResults] = useState<IAirport[]>([]);
+  const [flybackActive, setFlybackActive] = useState(true);
   const [checksPassed, setChecksPassed] = useState({
     firstLeg: false,
     additionalLegs: false,
@@ -188,7 +189,38 @@ const FlightSearch = () => {
   }, [searchFlightCriteria]);
 
   const onFinish = (values: any) => {
+
+     // Check if required fields are present
+  if (!values.departure || !values.arrival || !values.date || !values.seats) {
+    notification.error({
+      message: 'Missing Required Fields',
+      description: 'Please ensure you have selected departure, arrival, date, and number of passengers.',
+  
+    });
+    return;
+  }
+
+    // Check additional legs if they exist
+  if (values.legs && values.legs.length > 0) {
+    const invalidLeg = values.legs.find((leg: any, index: number) => 
+      !leg.departure || !leg.arrival || !leg.date
+    );
+
+    if (invalidLeg) {
+      notification.error({
+        message: 'Missing Required Fields',
+        description: 'Please ensure all additional legs have departure, arrival, and date selected.',
+      });
+      return;
+    }
+  }
+
+
+  
     // Add validation before processing
+
+
+
     const firstLeg = values.departure === values.arrival;
     const additionalLegsHaveSameAirports = values.legs?.some(
       (leg: any) => leg.departure === leg.arrival
@@ -740,11 +772,12 @@ const FlightSearch = () => {
               })}
               {checksPassed.additionalLegs && (
                 <FormControl id="trip-modifiers">
-                  <Button
-                    icon={<ArrowLeftOutlined />}
-                    type="primary"
-                    block
-                    style={{
+                  {flybackActive && (
+                    <Button
+                      icon={<ArrowLeftOutlined />}
+                      type="primary"
+                      block
+                      style={{
                       ...tripActionStyle,
                       width: "25%",
                       marginRight: "1rem",
@@ -779,10 +812,12 @@ const FlightSearch = () => {
 
                       add(newLeg);
                       runChecks();
+                      setFlybackActive(false);
                     }}
                   >
                     Fly back
                   </Button>
+                  )}
                   <Button
                     icon={<PlusOutlined />}
                     type="primary"

--- a/app/components/SearchBox/FlightSearch.tsx
+++ b/app/components/SearchBox/FlightSearch.tsx
@@ -766,12 +766,15 @@ const FlightSearch = () => {
                           )?.fullLabel ?? lastLeg.arrival)
                         : form.getFieldValue("arrival");
 
+                        const previousSeats = lastLeg?.seats ?? form.getFieldValue("seats");
+
                       const newLeg = {
                         departure: departureAirport,
                         arrival:
                           arrivalAirport?.fullLabel ??
                           form.getFieldValue("departure"),
                         date: lastLeg?.date ?? form.getFieldValue("date"),
+                        seats: previousSeats,
                       };
 
                       add(newLeg);
@@ -801,9 +804,13 @@ const FlightSearch = () => {
                           )?.fullLabel ?? lastLeg.arrival)
                         : form.getFieldValue("arrival");
 
+                         const previousSeats = lastLeg?.seats ?? form.getFieldValue("seats");
+
+
                       const newLeg = {
                         departure: departureAirport,
                         date: lastLeg?.date ?? form.getFieldValue("date"),
+                        seats: previousSeats,
                       };
 
                       add(newLeg);


### PR DESCRIPTION
Future dates should only allow for 12 months in advance

Arrival and departure required to search along with date and PAX

When searching with no date give feedback to put date

Fly Back only once

Subsequent leg PAX should remember previous leg pax and default to that


https://github.com/user-attachments/assets/e4d61146-8a3e-455b-a6cd-7170d3139295

